### PR TITLE
Upgrade osm4j-core and osm4j-pbf

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ repositories {
 }
 
 dependencies {
-    compile 'de.topobyte:osm4j-pbf:0.0.8'
-    compile 'de.topobyte:osm4j-core:0.0.19'
+    compile 'de.topobyte:osm4j-pbf:0.0.10'
+    compile 'de.topobyte:osm4j-core:0.0.20'
     compile group: 'org.apache.orc', name: 'orc-core', version: '1.3.0'
     compile 'org.openstreetmap.osmosis:osmosis-core:0.44.1'
     compile group: 'org.openstreetmap.osmosis', name: 'osmosis-xml', version: '0.44.1'


### PR DESCRIPTION
The support for the visible attribute was not yet working for densely coded nodes in PBF. This has been fixed in a more recent version: https://github.com/topobyte/osm4j-pbf/commit/9785b34cc6465203b900c2683105fe3858533489