### PR TITLE
[WIP] Move to smaller stripeSize in ORC file

### DIFF
--- a/src/main/java/net/mojodna/osm2orc/OrcUtils.java
+++ b/src/main/java/net/mojodna/osm2orc/OrcUtils.java
@@ -1,0 +1,22 @@
+package net.mojodna.osm2orc;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.orc.OrcFile;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.Writer;
+
+import java.io.IOException;
+
+public class OrcUtils {
+    private static final long STRIPE_SIZE = (64L * 1024 * 1024) / 128;
+
+    public static Writer createWriter(String filename, TypeDescription schema) throws IOException {
+      Configuration conf = new Configuration();
+      // conf.set(OrcConf.BLOOM_FILTER_COLUMNS.getAttribute(), "tags");
+      OrcFile.WriterOptions writerOptions =
+        OrcFile.writerOptions(conf).setSchema(schema).stripeSize(STRIPE_SIZE);
+
+      return OrcFile.createWriter(new Path(filename), writerOptions);
+    }
+}

--- a/src/main/java/net/mojodna/osm2orc/osmosis/OrcWriter.java
+++ b/src/main/java/net/mojodna/osm2orc/osmosis/OrcWriter.java
@@ -1,7 +1,7 @@
 package net.mojodna.osm2orc.osmosis;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
+import net.mojodna.osm2orc.OrcUtils;
+
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
@@ -247,10 +247,8 @@ public class OrcWriter implements Sink {
     @Override
     public void initialize(Map<String, Object> metaData) {
         try {
-            Configuration conf = new Configuration();
-            // conf.set(OrcConf.BLOOM_FILTER_COLUMNS.getAttribute(), "tags");
-            processor = new OrcEntityProcessor(OrcFile.createWriter(new Path(filename),
-                    OrcFile.writerOptions(conf).setSchema(SCHEMA)), SCHEMA.createRowBatch());
+            processor = new OrcEntityProcessor(OrcUtils.createWriter(filename, SCHEMA),
+                                               SCHEMA.createRowBatch());
         } catch (IOException e) {
             throw new OsmosisRuntimeException(e);
         }

--- a/src/main/java/net/mojodna/osm2orc/standalone/OsmChangesetXml2Orc.java
+++ b/src/main/java/net/mojodna/osm2orc/standalone/OsmChangesetXml2Orc.java
@@ -1,10 +1,10 @@
 package net.mojodna.osm2orc.standalone;
 
 
+import net.mojodna.osm2orc.OrcUtils;
 import net.mojodna.osm2orc.standalone.model.Changeset;
 import net.mojodna.osm2orc.standalone.parser.ChangesetXmlHandler;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
+
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
@@ -61,9 +61,7 @@ public class OsmChangesetXml2Orc {
 
     public void convert() throws Exception {
         // Setup ORC writer
-        Configuration conf = new Configuration();
-        Writer writer = OrcFile.createWriter(new Path(outputOrc),
-                OrcFile.writerOptions(conf).setSchema(SCHEMA));
+        Writer writer = OrcUtils.createWriter(outputOrc, SCHEMA);
 
         // Setup ORC vectors
         VectorizedRowBatch batch = SCHEMA.createRowBatch();

--- a/src/main/java/net/mojodna/osm2orc/standalone/OsmPbf2Orc.java
+++ b/src/main/java/net/mojodna/osm2orc/standalone/OsmPbf2Orc.java
@@ -1,6 +1,8 @@
 package net.mojodna.osm2orc.standalone;
 
 
+import net.mojodna.osm2orc.OrcUtils;
+
 import de.topobyte.osm4j.core.access.OsmIterator;
 import de.topobyte.osm4j.core.model.iface.EntityContainer;
 import de.topobyte.osm4j.core.model.iface.OsmEntity;
@@ -10,8 +12,6 @@ import de.topobyte.osm4j.core.model.iface.OsmRelation;
 import de.topobyte.osm4j.core.model.iface.OsmWay;
 import de.topobyte.osm4j.core.model.util.OsmModelUtil;
 import de.topobyte.osm4j.pbf.seq.PbfIterator;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
@@ -91,11 +91,7 @@ public class OsmPbf2Orc {
 //                .addField("currentTransaction", createLong())
 //                .addField("row", schema);
 
-
-        Configuration conf = new Configuration();
-//        conf.set(OrcConf.BLOOM_FILTER_COLUMNS.getAttribute(), "tags");
-        Writer writer = OrcFile.createWriter(new Path(outputOrc),
-                OrcFile.writerOptions(conf).setSchema(schema));
+        Writer writer = OrcUtils.createWriter(outputOrc, schema);
 
 //        writer.addUserMetadata("bbox", null);
 //        // TODO osm.schema.version = 0.6


### PR DESCRIPTION
Fixes #5 
This is WIP because I tried to run some local tests to verify this solves the problem I was experiencing in the original PR. I could not get the partition count to vary as I changed the stripeSize value, so that testing must be ongoing. As that might be a SparkSQL issue and this may be a good fit for other systems, if there's an Presto testing that could verify this change, that would be helpful.