### PR TITLE
Remove history option and unify schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,26 +26,6 @@ LOCATION 's3://osm-pds/planet/';
 ```
 
 ```sql
-CREATE EXTERNAL TABLE planet_history (
-    id BIGINT,
-    type STRING,
-    tags MAP<STRING,STRING>,
-    lat DECIMAL(9,7),
-    lon DECIMAL(10,7),
-    nds ARRAY<STRUCT<ref: BIGINT>>,
-    members ARRAY<STRUCT<type: STRING, ref: BIGINT, role: STRING>>,
-    changeset BIGINT,
-    timestamp TIMESTAMP,
-    uid BIGINT,
-    user STRING,
-    version BIGINT,
-    visible BOOLEAN
-)
-STORED AS ORCFILE
-LOCATION 's3://osm-pds/planet-history/';
-```
-
-```sql
 CREATE EXTERNAL TABLE changesets (
     id BIGINT,
     tags MAP<STRING,STRING>,

--- a/README.md
+++ b/README.md
@@ -19,10 +19,31 @@ CREATE EXTERNAL TABLE planet (
     timestamp TIMESTAMP,
     uid BIGINT,
     user STRING,
-    version BIGINT
+    version BIGINT,
+    visible BOOLEAN
 )
 STORED AS ORCFILE
 LOCATION 's3://osm-pds/planet/';
+```
+
+```sql
+CREATE EXTERNAL TABLE planet_history (
+    id BIGINT,
+    type STRING,
+    tags MAP<STRING,STRING>,
+    lat DECIMAL(9,7),
+    lon DECIMAL(10,7),
+    nds ARRAY<STRUCT<ref: BIGINT>>,
+    members ARRAY<STRUCT<type: STRING, ref: BIGINT, role: STRING>>,
+    changeset BIGINT,
+    timestamp TIMESTAMP,
+    uid BIGINT,
+    user STRING,
+    version BIGINT,
+    visible BOOLEAN
+)
+STORED AS ORCFILE
+LOCATION 's3://osm-pds/planet-history/';
 ```
 
 ```sql

--- a/src/main/java/net/mojodna/osm2orc/Osm2Orc.java
+++ b/src/main/java/net/mojodna/osm2orc/Osm2Orc.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class Osm2Orc {
     public static void main(String[] args) throws Exception {
         if (args.length < 2) {
-            System.err.println("Usage: osm2orc [--changesets] [--history] <input> <output>");
+            System.err.println("Usage: osm2orc [--changesets] <input> <output>");
             System.exit(1);
         }
 
@@ -30,21 +30,13 @@ public class Osm2Orc {
 
         final InputStream inputStream;
 
-        boolean history = false;
-
-        if (args[0].equals("--history")) {
-            history = true;
-            List<String> argList = Arrays.asList(args);
-            args = argList.subList(1, argList.size()).toArray(args);
-        }
-
         if (args[0].equals("-")) {
             inputStream = System.in;
         } else {
             inputStream = new FileInputStream(args[0]);
         }
 
-        OsmPbf2Orc.convert(inputStream, args[1], history);
+        OsmPbf2Orc.convert(inputStream, args[1]);
         System.exit(0);
     }
 }

--- a/src/main/java/net/mojodna/osm2orc/standalone/OsmPbf2Orc.java
+++ b/src/main/java/net/mojodna/osm2orc/standalone/OsmPbf2Orc.java
@@ -48,7 +48,7 @@ public class OsmPbf2Orc {
     private static final byte[] WAY_BYTES = "way".getBytes();
     private static final byte[] RELATION_BYTES = "relation".getBytes();
 
-    public static void convert(InputStream input, String outputOrc, boolean history) throws IOException {
+    public static void convert(InputStream input, String outputOrc) throws IOException {
         TypeDescription schema = createStruct()
                 .addField("id", createLong())
                 .addField("type", createString())
@@ -72,11 +72,8 @@ public class OsmPbf2Orc {
                 .addField("timestamp", createTimestamp())
                 .addField("uid", createLong())
                 .addField("user", createString())
-                .addField("version", createLong());
-
-        if (history) {
-            schema.addField("visible", createBoolean());
-        }
+                .addField("version", createLong())
+                .addField("visible", createBoolean());
 
 //        TypeDescription deltaSchema = createStruct()
 //                .addField("operation", createInt())
@@ -133,13 +130,7 @@ public class OsmPbf2Orc {
         LongColumnVector uid = (LongColumnVector) batch.cols[9];
         BytesColumnVector user = (BytesColumnVector) batch.cols[10];
         LongColumnVector version = (LongColumnVector) batch.cols[11];
-        final LongColumnVector visible;
-
-        if (history) {
-            visible = (LongColumnVector) batch.cols[12];
-        } else {
-            visible = null;
-        }
+        LongColumnVector visible = (LongColumnVector) batch.cols[12];
 
         OsmIterator iterator = new PbfIterator(input, true);
         // parallel will make it faster but will produce bigger output files
@@ -195,11 +186,10 @@ public class OsmPbf2Orc {
 
             version.vector[row] = metadata.getVersion();
 
-            if (history) {
+            if (!metadata.isVisible()) {
+                visible.vector[row] = 0;
+            } else {
                 visible.vector[row] = 1;
-                if (!metadata.isVisible()) {
-                    visible.vector[row] = 0;
-                }
             }
 
             synchronized (nds) {


### PR DESCRIPTION
This PR implements the change suggested in issue #7. The changeset here is pretty straightforward: I removed the command line flag `--history` and got rid of any flow-control related to it. 