### PR TITLE
Treat missing node coordinates as null

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'de.topobyte', name: 'osm4j-pbf', version: '0.1.0'
+    compile group: 'de.topobyte', name: 'osm4j-pbf', version: '0.1.1'
     compile group: 'de.topobyte', name: 'osm4j-core', version: '0.1.0'
     compile group: 'org.apache.orc', name: 'orc-core', version: '1.4.3'
     compile group: 'org.openstreetmap.osmosis', name: 'osmosis-core', version: '0.46'

--- a/src/main/java/net/mojodna/osm2orc/standalone/OsmPbf2Orc.java
+++ b/src/main/java/net/mojodna/osm2orc/standalone/OsmPbf2Orc.java
@@ -201,12 +201,11 @@ public class OsmPbf2Orc {
 
                     OsmNode node = (OsmNode) entity;
 
-                    // sometimes these have invalid values, e.g. 214.7483647
-                    if (node.getLatitude() != 214.74836470000002) {
+                    if (!Double.isNaN(node.getLatitude())) {
                         lat.set(row, HiveDecimal.create(node.getLatitude()));
                     }
 
-                    if (node.getLongitude() != 214.74836470000002) {
+                    if (!Double.isNaN(node.getLongitude())) {
                         lon.set(row, HiveDecimal.create(node.getLongitude()));
                     }
 


### PR DESCRIPTION
Depends on https://github.com/topobyte/osm4j-pbf/pull/5, in which case `osm4j-pbf`'s version will need to be updated.